### PR TITLE
Set your TREZOR's homescreens via webwallet

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -206,10 +206,12 @@
     <script src="scripts/services/uriRedirect.js"></script>
     <script src="scripts/services/modalOpener.js"></script>
     <script src="scripts/services/forgetModalService.js"></script>
+    <script src="scripts/services/fileReader.js"></script>
     <!-- directives -->
     <script src="scripts/directives/flashMessages.js"></script>
     <script src="scripts/directives/qrScan.js"></script>
     <script src="scripts/directives/focus.js"></script>
+    <script src="scripts/directives/homescreenImage.js"></script>
     <!-- controllers -->
     <script src="scripts/controllers/debug.js"></script>
     <script src="scripts/controllers/error.js"></script>

--- a/app/scripts/directives/homescreenImage.js
+++ b/app/scripts/directives/homescreenImage.js
@@ -1,0 +1,124 @@
+angular.module('webwalletApp')
+.directive('homescreenimage', function($q) {
+    'use strict';
+
+    var URL = window.URL || window.webkitURL;
+
+    var getCanvas = function () {
+        var canvasId = 'homescreen-canvas';
+        var canvas = document.getElementById(canvasId);
+
+        if (!canvas) {
+            canvas = document.createElement('canvas');
+            canvas.id = canvasId;
+            canvas.style.visibility = 'hidden';
+            document.body.appendChild(canvas);
+        }
+
+        return canvas;
+    };
+
+    var processImage = function (origImage) {
+        var height = 64;
+        var width = 128;
+        var quality = 0.7;
+        var type = 'image/jpg';
+
+        var canvas = getCanvas();
+        canvas.width = width;
+        canvas.height = height;
+
+        var ctx = canvas.getContext("2d");
+        ctx.drawImage(origImage, 0, 0, width, height);
+        var imageData = ctx.getImageData(0,0, width, height);
+
+        // Convert o B&W (not grayscale) using average
+        for (var j=0; j<imageData.height; j++)
+        {
+            for (var i=0; i<imageData.width; i++)
+            {
+                var index=(j*4)*imageData.width+(i*4);
+                var red=imageData.data[index];
+                var green=imageData.data[index+1];
+                var blue=imageData.data[index+2];
+                var average=(red+green+blue)/3;
+                var color = 255;
+                if(average<128) { //force B&W, not grayscale
+                    color = 0;
+                }
+                imageData.data[index] = color;
+                imageData.data[index+1] = color;
+                imageData.data[index+2] = color;
+                imageData.data[index+3] = 255;
+            }
+        }
+        ctx.putImageData(imageData,0,0,0,0, imageData.width,   imageData.height);
+        return canvas.toDataURL(type, quality);
+    };
+
+    var createImage = function(url, callback) {
+        var image = new Image();
+        image.onload = function() {
+            callback(image);
+        };
+        image.src = url;
+    };
+
+    var fileToDataURL = function (file) {
+        var deferred = $q.defer();
+        var reader = new FileReader();
+        reader.onload = function (e) {
+            deferred.resolve(e.target.result);
+        };
+        reader.readAsDataURL(file);
+        return deferred.promise;
+    };
+
+
+    return {
+        restrict: 'A',
+        scope: {
+            homescreenimage: '='
+        },
+        link: function postLink(scope, element, attrs) {
+
+            var doProcess = function(imageResult, callback) {
+                createImage(imageResult.url, function(image) {
+                    var dataURL = processImage(image);
+                    imageResult.preview = {
+                        dataURL: dataURL,
+                        type: dataURL.match(/:(.+\/.+);/)[1]
+                    };
+                    callback(imageResult);
+                });
+            };
+
+            var applyScope = function(imageResult) {
+                scope.$apply(function() {
+                    scope.homescreenimage = imageResult;
+                });
+            };
+
+
+            element.bind('change', function (evt) {
+
+                var files = evt.target.files;
+                for(var i = 0; i < files.length; i++) {
+                    var imageResult = {
+                        file: files[i],
+                        url: URL.createObjectURL(files[i])
+                    };
+
+                    fileToDataURL(files[i]).then(function (dataURL) {
+                        imageResult.dataURL = dataURL;
+                    });
+
+
+                    doProcess(imageResult, function(imageResult) {
+                        applyScope(imageResult);
+                    });
+                }
+            });
+        }
+    };
+});

--- a/app/scripts/services/TrezorDevice.js
+++ b/app/scripts/services/TrezorDevice.js
@@ -522,6 +522,18 @@ angular.module('webwalletApp').factory('TrezorDevice', function (
         });
     };
 
+    TrezorDevice.prototype.changeHomeScreen = function (homescreen) {
+        var self = this;
+
+        return self.withLoading(function () {
+            return self._session.initialize()
+                .then(function () {
+                    return self._session.applySettings({ homescreen: homescreen });
+                })
+                .then(function () { return self.initializeDevice(); });
+        });
+    };
+
     TrezorDevice.prototype.changeLabel = function (label) {
         var self = this;
 

--- a/app/scripts/services/fileReader.js
+++ b/app/scripts/services/fileReader.js
@@ -1,0 +1,56 @@
+(function (module) {
+
+    var fileReader = function ($q, $log) {
+
+        var onLoad = function(reader, deferred, scope) {
+            return function () {
+                scope.$apply(function () {
+                    deferred.resolve(reader.result);
+                });
+            };
+        };
+
+        var onError = function (reader, deferred, scope) {
+            return function () {
+                scope.$apply(function () {
+                    deferred.reject(reader.result);
+                });
+            };
+        };
+
+        var onProgress = function(reader, scope) {
+            return function (event) {
+                scope.$broadcast("fileProgress",
+                    {
+                        total: event.total,
+                        loaded: event.loaded
+                    });
+            };
+        };
+
+        var getReader = function(deferred, scope) {
+            var reader = new FileReader();
+            reader.onload = onLoad(reader, deferred, scope);
+            reader.onerror = onError(reader, deferred, scope);
+            reader.onprogress = onProgress(reader, scope);
+            return reader;
+        };
+
+        var readAsDataURL = function (file, scope) {
+            var deferred = $q.defer();
+
+            var reader = getReader(deferred, scope);
+            reader.readAsDataURL(file);
+
+            return deferred.promise;
+        };
+
+        return {
+            readAsDataUrl: readAsDataURL
+        };
+    };
+
+    module.factory("fileReader",
+        ["$q", "$log", fileReader]);
+
+}(angular.module("webwalletApp")));

--- a/app/views/device/index.info.html
+++ b/app/views/device/index.info.html
@@ -1,9 +1,13 @@
 <h3>
   {{device.label()}}
-  <button class="btn btn-default pull-right"
-          ng-click="changeLabel(device)">
-    <span class="glyphicon glyphicon-pencil"></span> Change label
-  </button>
+    <button class="btn btn-default pull-right"
+            ng-click="changeLabel(device)">
+        <span class="glyphicon glyphicon-pencil"></span> Change label
+    </button>
+    <button class="btn btn-default pull-right"
+            ng-click="changeHomeScreen(device)">
+        <span class="glyphicon glyphicon-pencil"></span> Change homescreen
+    </button>
 </h3>
 <p class="lead"
    ng-hide="device.isLoading()"

--- a/app/views/modal/homescreen.html
+++ b/app/views/modal/homescreen.html
@@ -1,0 +1,17 @@
+<div class="modal-header">
+  <button type="button" class="close" title="Cancel"
+          ng-click="$dismiss()">&times;</button>
+  <h4 class="modal-title">Please select a image for the device homescreen</h4>
+</div>
+<div class="modal-body">
+  <form class="form-inline"
+        ng-submit="$close(homescreen)">
+    <div class="form-group">
+        <input type="file" accept="image/*" homescreenimage="homescreenimage" />
+        <img id="homescreenpreview" ng-show="homescreenimage" ng-src="{{homescreenimage.preview.dataURL}}" />
+    </div>
+    <div class="form-group">
+      <button type="submit" class="btn btn-primary btn-lg">Change</button>
+    </div>
+  </form>
+</div>


### PR DESCRIPTION
In the info panel of the webwallet a new button to change your homescreen is placed. Said button will open a modal window that allows you to select an image.

The image is then resized to 128x64 and converted to black&white, shown as a preview to the user, which could then decide to cancel the process or send it to the TREZOR (confirmation is required).

I'm not good at CSS, texts could be improved too. You probably want to change that.

I didn't comment the source, but left some comments on the commit that may help understand it.

Work best with b&w images. An example of the process could be seen here : https://twitter.com/_CONEJO/status/624847354626187264
